### PR TITLE
Add travis link checker config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 2.2
+before_script:
+  - gem install awesome_bot
+script:
+  - awesome_bot README.md --allow-dupe --allow-redirect

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md --allow-dupe --allow-redirect
+  - awesome_bot README.md --allow-dupe --allow-redirect --whitelist https://osrc.dfm.io,https://www.gitbook.io/book/gitbookio/markdown

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md --allow-dupe --allow-redirect --whitelist https://osrc.dfm.io,https://www.gitbook.io/book/gitbookio/markdown
+  - awesome_bot README.md --allow-dupe --allow-redirect --white-list https://osrc.dfm.io

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ A curated list of awesome GitHub tools, libraries, resources, and shiny things.
 
 * [Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
 * [Markdown Here Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Here-Cheatsheet)
-* [Learn Markdown](https://www.gitbook.io/book/gitbookio/markdown) (PDF) (EPUB) (MOBI) - GitBookIO, Sammy P., Aaron O.
+* [Learn Markdown](https://www.gitbook.com/book/gitbookio/markdown) (PDF) (EPUB) (MOBI) - GitBookIO, Sammy P., Aaron O.
 
 ## Lists
 


### PR DESCRIPTION
- Added a travis-ci.org configuration to link check README.md
- awesome_bot detected that gitbook.io was redirecting to gitbook.com which broke the https link, updated the link to reflect that.
