### PR TITLE
Add Pull Request Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ A curated list of awesome GitHub tools, libraries, resources, and shiny things.
 + [GitHub Analytics for Open-Source](https://gitspo.com/)
 + [GitHub Trending Repos](https://github.com/vitalets/github-trending-repos) - Follow new trending repositories in your favorite programming language via GitHub notifications.
 + [CoderStats](https://coderstats.net/) - View statistics for GitHub users and organizations.
++ [Pull Request Badge](https://pullrequestbadge.com/) Programatically insert badges in your pull request descriptions and then link them to anything.
 
 ## Emoji
 


### PR DESCRIPTION
Add context to your pull request descriptions. [Pull Request Badge](https://pullrequestbadge.com/) is a GitHub app that lets you programatically insert badges in your pull request descriptions and then link them to anything.

<img src="https://user-images.githubusercontent.com/1393946/92336561-4d45a700-f0a2-11ea-9c48-913f913fc856.png" width="400" />
